### PR TITLE
Disable RELRO

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -199,7 +199,7 @@ endif
 ARFLAGS := rDv
 ASFLAGS += $(ARCH3264)
 LDFLAGS	+= -nostdlib --warn-common --no-undefined --fatal-warnings \
-	   --build-id=sha1 -z nocombreloc
+	   --build-id=sha1 -z nocombreloc -z norelro
 
 ifneq ($(ARCH),arm)
 export LIBGCC=$(shell $(CC) $(CFLAGS) $(ARCH3264) -print-libgcc-file-name)


### PR DESCRIPTION
No point having PT_GNU_RELRO as ELF data won't exist when merging into PE32+ file

Unbreaks lld usage which complains about linker script
Fixes ncroxon/gnu-efi#4