### PR TITLE
Align RTLIB CopyMem/SetMem with normal versions

### DIFF
--- a/inc/efirtlib.h
+++ b/inc/efirtlib.h
@@ -45,6 +45,7 @@ RtZeroMem (
     );
 
 VOID
+EFIAPI
 RUNTIMEFUNCTION
 RtSetMem (
     IN VOID     *Buffer,
@@ -53,10 +54,11 @@ RtSetMem (
     );
 
 VOID
+EFIAPI
 RUNTIMEFUNCTION
 RtCopyMem (
     IN VOID     *Dest,
-    IN CONST VOID     *Src,
+    IN VOID     *Src,
     IN UINTN    len
     );
 

--- a/lib/runtime/efirtlib.c
+++ b/lib/runtime/efirtlib.c
@@ -42,6 +42,7 @@ RtZeroMem (
 #pragma RUNTIME_CODE(RtSetMem)
 #endif
 VOID
+EFIAPI
 RUNTIMEFUNCTION
 RtSetMem (
     IN VOID     *Buffer,
@@ -61,10 +62,11 @@ RtSetMem (
 #pragma RUNTIME_CODE(RtCopyMem)
 #endif
 VOID
+EFIAPI
 RUNTIMEFUNCTION
 RtCopyMem (
     IN VOID        *Dest,
-    IN CONST VOID  *Src,
+    IN VOID  *Src,
     IN UINTN       len
     )
 {

--- a/lib/runtime/rtstr.c
+++ b/lib/runtime/rtstr.c
@@ -69,10 +69,13 @@ RtStrnCpy (
     )
 // copy strings
 {
+    CHAR16 CopySrc = *Src;
+    CHAR16 *PCopySrc = &CopySrc;
+    
     UINTN Size = RtStrnLen(Src, Len);
     if (Size != Len)
         RtSetMem(Dest + Size, (Len - Size) * sizeof(CHAR16), '\0');
-    RtCopyMem(Dest, Src, Size * sizeof(CHAR16));
+    RtCopyMem(Dest, PCopySrc, Size * sizeof(CHAR16));
 }
 
 #ifndef __GNUC__
@@ -105,10 +108,13 @@ RtStpnCpy (
     )
 // copy strings
 {
+    CHAR16 CopySrc = *Src;
+    CHAR16 *PCopySrc = &CopySrc;
+    
     UINTN Size = RtStrnLen(Src, Len);
     if (Size != Len)
         RtSetMem(Dest + Size, (Len - Size) * sizeof(CHAR16), '\0');
-    RtCopyMem(Dest, Src, Size * sizeof(CHAR16));
+    RtCopyMem(Dest, PCopySrc, Size * sizeof(CHAR16));
     return Dest + Size;
 }
 
@@ -137,10 +143,12 @@ RtStrnCat (
     )
 {
     UINTN DestSize, Size;
+    CHAR16 CopySrc = *Src;
+    CHAR16 *PCopySrc = &CopySrc;
 
     DestSize = RtStrLen(Dest);
     Size = RtStrnLen(Src, Len);
-    RtCopyMem(Dest + DestSize, Src, Size * sizeof(CHAR16));
+    RtCopyMem(Dest + DestSize, PCopySrc, Size * sizeof(CHAR16));
     Dest[DestSize + Size] = '\0';
 }
 

--- a/lib/str.c
+++ b/lib/str.c
@@ -201,11 +201,13 @@ StrDuplicate (
 {
     CHAR16      *Dest;
     UINTN       Size;
+    CHAR16      CopySrc = *Src;
+    CHAR16      *PCopySrc = &CopySrc;
 
     Size = StrSize(Src);
     Dest = AllocatePool (Size);
     if (Dest) {
-        CopyMem (Dest, (void *)Src, Size);
+        CopyMem (Dest, PCopySrc, Size);
     }
     return Dest;
 }


### PR DESCRIPTION

Looks like 699e452654df6de53890ae994756b0d47237e3ac broke rEFInd (https://sourceforge.net/p/refind/code/ci/189e405630293445df8565e36b831bba56e87093/)


UNTESTED!!! 