### PR TITLE
Replace 'Copright' with 'Copyright' in file headers

### DIFF
--- a/gnuefi/crt0-efi-aarch64.S
+++ b/gnuefi/crt0-efi-aarch64.S
@@ -1,7 +1,7 @@
 /*
  * crt0-efi-aarch64.S - PE/COFF header for AArch64 EFI applications
  *
- * Copright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
+ * Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/gnuefi/crt0-efi-arm.S
+++ b/gnuefi/crt0-efi-arm.S
@@ -1,7 +1,7 @@
 /*
  * crt0-efi-arm.S - PE/COFF header for ARM EFI applications
  *
- * Copright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
+ * Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/gnuefi/crt0-efi-mips64el.S
+++ b/gnuefi/crt0-efi-mips64el.S
@@ -1,8 +1,8 @@
 /*
  * crt0-efi-mips64el.S - PE/COFF header for MIPS64 EFI applications
  *
- * Copright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
- * Copright (C) 2017 Heiher <r@hev.cc>
+ * Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
+ * Copyright (C) 2017 Heiher <r@hev.cc>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/gnuefi/crt0-efi-riscv64.S
+++ b/gnuefi/crt0-efi-riscv64.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0+ OR BSD-2-Clause */
 /*
- * Copright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
- * Copright (C) 2018 Alexander Graf <agraf@suse.de>
+ * Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
+ * Copyright (C) 2018 Alexander Graf <agraf@suse.de>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/inc/aarch64/efibind.h
+++ b/inc/aarch64/efibind.h
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 - 2015 Linaro Ltd.
+ * Copyright (C) 2014 - 2015 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/inc/arm/efibind.h
+++ b/inc/arm/efibind.h
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 - 2015 Linaro Ltd.
+ * Copyright (C) 2014 - 2015 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/inc/loongarch64/efibind.h
+++ b/inc/loongarch64/efibind.h
@@ -1,9 +1,9 @@
 /*
- * Copright (C) 2014 - 2015 Linaro Ltd.
+ * Copyright (C) 2014 - 2015 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
- * Copright (C) 2017 Lemote Co.
+ * Copyright (C) 2017 Lemote Co.
  * Author: Heiher <r@hev.cc>
- * Copright (C) 2021 Loongson Technology Corporation Limited.
+ * Copyright (C) 2021 Loongson Technology Corporation Limited.
  * Author: zhoumingtao <zhoumingtao@loongson.cn>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/inc/mips64el/efibind.h
+++ b/inc/mips64el/efibind.h
@@ -1,7 +1,7 @@
 /*
- * Copright (C) 2014 - 2015 Linaro Ltd.
+ * Copyright (C) 2014 - 2015 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
- * Copright (C) 2017 Lemote Co.
+ * Copyright (C) 2017 Lemote Co.
  * Author: Heiher <r@hev.cc>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/inc/riscv64/efibind.h
+++ b/inc/riscv64/efibind.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0+ OR BSD-2-Clause */
 /*
- * Copright (C) 2014 - 2015 Linaro Ltd.
+ * Copyright (C) 2014 - 2015 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/aarch64/initplat.c
+++ b/lib/aarch64/initplat.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/aarch64/math.c
+++ b/lib/aarch64/math.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/arm/initplat.c
+++ b/lib/arm/initplat.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/arm/math.c
+++ b/lib/arm/math.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/loongarch64/initplat.c
+++ b/lib/loongarch64/initplat.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/loongarch64/math.c
+++ b/lib/loongarch64/math.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/mips64el/initplat.c
+++ b/lib/mips64el/initplat.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/mips64el/math.c
+++ b/lib/mips64el/math.c
@@ -1,5 +1,5 @@
 /*
- * Copright (C) 2014 Linaro Ltd.
+ * Copyright (C) 2014 Linaro Ltd.
  * Author: Ard Biesheuvel <ard.biesheuvel@linaro.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/mips64el/setjmp.S
+++ b/lib/mips64el/setjmp.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.
- * Copright (c) 2017 Lemote Co.
+ * Copyright (c) 2017 Lemote Co.
  * Author: Heiher <r@hev.cc>
  *
  * This program and the accompanying materials are licensed and made


### PR DESCRIPTION
This was hopefully just a typo that has been cargo-culted around the codebase.

It certainly confuses the Red Hat license checker and makes the code copyright clear.