### PR TITLE
Fix ‘asm’ undeclared error for MIPS builds

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -20,7 +20,7 @@ jobs:
           - { arch: aa64, gcc: aarch64-linux-gnu, cross_compile: aarch64-linux-gnu- }
           - { arch: arm, gcc: arm-linux-gnueabihf, cross_compile: arm-linux-gnueabihf- }
           - { arch: riscv64, gcc: riscv64-linux-gnu, cross_compile: riscv64-linux-gnu- }
-#          - { arch: mips64el, gcc: mips64el-linux-gnuabi64, cross_compile: mips64el-linux-gnuabi64- }
+          - { arch: mips64el, gcc: mips64el-linux-gnuabi64, cross_compile: mips64el-linux-gnuabi64- }
 #          - { arch: loongarch64, gcc: loongarch64-linux-gnu, cross_compile: loongarch64-linux-gnu- }
 
     steps:

--- a/inc/mips64el/efibind.h
+++ b/inc/mips64el/efibind.h
@@ -158,7 +158,7 @@ typedef uint64_t   UINTN;
 
 static inline UINT64 swap_uint64 (UINT64 v)
 {
-	asm volatile (
+	__asm__ volatile (
 		"dsbh	%[v], %[v] \n\t"
 		"dshd	%[v], %[v] \n\t"
 		:[v]"+r"(v)


### PR DESCRIPTION
As explained at https://stackoverflow.com/a/49830956/1069307, `asm` is a GNU extension that will produce an error when using a non GNU standard like `-std=c11`. With recent commit 9b1e06cd0cc7937ae291a34f1bb5ec1b4568faee having fixed our use of `-std=c11`, the MIPS build failed with the error above.

With this sorted, we also re-enable the MIPS gcc build in GitHub Actions.