### PR TITLE
Actually make the apps build with MinGW

### DIFF
--- a/.github/workflows/linux-mingw.yml
+++ b/.github/workflows/linux-mingw.yml
@@ -28,4 +28,4 @@ jobs:
       run: sudo apt install ${{ matrix.pkg }}
 
     - name: Build
-      run: make ARCH=${{ matrix.arch }} CROSS_COMPILE=${{ matrix.tuple }} lib
+      run: make ARCH=${{ matrix.arch }} CROSS_COMPILE=${{ matrix.tuple }}

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -39,4 +39,4 @@ jobs:
         submodules: recursive
 
     - name: Build
-      run: make lib
+      run: make

--- a/Make.defaults
+++ b/Make.defaults
@@ -189,8 +189,11 @@ INCDIR  += -I$(SRCDIR) -I$(TOPDIR)/inc -I$(TOPDIR)/inc/$(ARCH) \
 
 # Only enable -fPIE for non MinGW compilers (unneeded on MinGW)
 GCCMACHINE := $(shell $(CC) -dumpmachine)
-ifneq (mingw32,$(findstring mingw32, $(GCCMACHINE)))
+IS_MINGW32 := $(findstring mingw32, $(GCCMACHINE))
+ifeq ($(IS_MINGW32),)
   CFLAGS += -fPIE
+else
+  CFLAGS += -DGNU_EFI_USE_MS_ABI
 endif
 
 ifeq (FreeBSD, $(findstring FreeBSD, $(OS)))
@@ -207,7 +210,10 @@ endif
 ARFLAGS := rDv
 ASFLAGS += $(ARCH3264)
 LDFLAGS	+= -nostdlib --warn-common --no-undefined --fatal-warnings \
-	   --build-id=sha1 -z nocombreloc -z norelro
+	   --build-id=sha1
+ifeq ($(IS_MINGW32),)
+  LDFLAGS += -z nocombreloc -z norelro
+endif
 
 ifneq ($(ARCH),arm)
 export LIBGCC=$(shell $(CC) $(CFLAGS) $(ARCH3264) -print-libgcc-file-name)

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,19 @@ VPATH = $(SRCDIR)
 
 include $(SRCDIR)/Make.defaults
 
-SUBDIRS = lib gnuefi inc apps
+SUBDIRS    = lib inc apps
+ifeq ($(IS_MINGW32),)
+  SUBDIRS += gnuefi
+endif
 
 all:	check_gcc $(SUBDIRS)
 
+ifeq ($(IS_MINGW32),)
 gnuefi: lib
 apps:	gnuefi
+else
+apps:	lib
+endif
 
 mkvars:
 	@echo AR=$(AR)

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -44,25 +44,36 @@ include $(SRCDIR)/../Make.defaults
 LINUX_HEADERS	= /usr/src/sys/build
 APPSDIR		= $(LIBDIR)/gnuefi/apps
 CPPFLAGS	+= -D__KERNEL__ -I$(LINUX_HEADERS)/include
+ifeq ($(IS_MINGW32),)
+# The CRT0 libs are only needed for non MinGW platforms
+CRT0_LIBS	= -lgnuefi
+endif
+
+ifneq ($(CRT0_LIBS),)
 CRTOBJS		= $(TOPDIR)/$(ARCH)/gnuefi/crt0-efi-$(ARCH).o
 
 LDSCRIPT	= $(TOPDIR)/gnuefi/elf_$(ARCH)_efi.lds
 ifneq (,$(findstring FreeBSD,$(OS)))
 LDSCRIPT	= $(TOPDIR)/gnuefi/elf_$(ARCH)_fbsd_efi.lds
 endif
-
-LDFLAGS		+= -shared -Bsymbolic -L$(TOPDIR)/$(ARCH)/lib -L$(TOPDIR)/$(ARCH)/gnuefi $(CRTOBJS)
-
-LOADLIBES	+= -lefi -lgnuefi
-LOADLIBES	+= $(LIBGCC)
+LDFLAGS		+= -L$(TOPDIR)/$(ARCH)/lib -L$(TOPDIR)/$(ARCH)/gnuefi $(CRTOBJS)
 LOADLIBES	+= -T $(LDSCRIPT)
+endif
 
-TARGET_APPS = t.efi t2.efi t3.efi t4.efi t5.efi t6.efi \
-	      printenv.efi t7.efi t8.efi tcc.efi modelist.efi \
-	      route80h.efi drv0_use.efi AllocPages.efi exit.efi \
-	      FreePages.efi setjmp.efi debughook.efi debughook.efi.debug \
-	      bltgrid.efi lfbgrid.efi setdbg.efi unsetdbg.efi \
-	      ctors_test.efi ctors_dtors_priority_test.efi
+LDFLAGS		+= -shared -Bsymbolic -L$(TOPDIR)/$(ARCH)/lib
+
+LOADLIBES	+= -lefi $(CRT0_LIBS)
+LOADLIBES	+= $(LIBGCC)
+
+TARGET_APPS = t.efi t2.efi t3.efi t4.efi t5.efi t6.efi t7.efi t8.efi \
+	      tcc.efi printenv.efi modelist.efi route80h.efi route80h.efi \
+	      drv0_use.efi AllocPages.efi exit.efi FreePages.efi bltgrid.efi \
+	      lfbgrid.efi setdbg.efi unsetdbg.efi ctors_test.efi \
+	      ctors_dtors_priority_test.efi
+ifeq ($(IS_MINGW32),)
+TARGET_APPS += setjmp.efi debughook.efi debughook.efi.debug
+endif
+
 TARGET_BSDRIVERS = drv0.efi
 TARGET_RTDRIVERS =
 


### PR DESCRIPTION
To builds the apps with MinGW, the CRT0 library must be ignored because it is ELF specific and we don't need to go through ELF relocations. We also apply the `GNU_EFI_USE_MS_ABI` flag (since we have it), remove the `-z` flags, that are invalid in MinGW, and clean up the apps Makefile.

Note that `setjump` and `debughook` are excluded from MinGW builds as they use constructs that are not available there.