### PR TITLE
Add RISCV64 testing support and default to clean compiler output

### DIFF
--- a/.github/workflows/linux-gcc.yml
+++ b/.github/workflows/linux-gcc.yml
@@ -60,12 +60,12 @@ jobs:
         path: ./${{ matrix.dir }}/apps/*.efi
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     strategy:
       matrix:
-        arch: [x64, ia32, aa64, arm]
+        arch: [x64, ia32, aa64, arm, riscv64]
         include:
         - arch: x64
           pkg: qemu-system-x86
@@ -87,6 +87,11 @@ jobs:
           qemu_arch: arm
           qemu_opts: -M virt -cpu cortex-a15
           fw_base: AAVMF
+        - arch: riscv64
+          pkg: qemu-system-riscv64
+          qemu_arch: riscv64
+          qemu_opts: -M virt,pflash0=pflash0
+          fw_base: QEMU_EFI
 
     steps:
     - name: Set up Linux environment
@@ -121,8 +126,12 @@ jobs:
 
     - name: Run tests
       run: |
-         export UEFI_ARCH=${{ matrix.arch }}
-         export UEFI_DIR=./image
-         export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image -nodefaults -nographic -serial stdio -net none"
-         ./tests/gen_tests.sh ./tests/test_list.txt
-         ./tests/run_tests.sh
+        export UEFI_ARCH=${{ matrix.arch }}
+        export UEFI_DIR=./image
+        if [ "$UEFI_ARCH" = "riscv64" ]; then\
+          export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -blockdev node-name=pflash0,driver=file,read-only=on,filename=${{ matrix.fw_base }}.fd -drive format=raw,file=fat:rw:image,id=drv1 -device virtio-blk-device,drive=drv1"
+        else \
+          export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image"
+        fi
+        ./tests/gen_tests.sh ./tests/test_list.txt
+        ./tests/run_tests.sh

--- a/Make.defaults
+++ b/Make.defaults
@@ -60,9 +60,9 @@ override INSTALLROOT:=$(if $(call is_absolute,$(INSTALLROOT)),,$(TOPDIR)/)$(INST
 
 PREFIX       := /usr/local
 EXEC_PREFIX  := $(PREFIX)
-LIBDIR 	 := $(EXEC_PREFIX)/lib
+LIBDIR       := $(EXEC_PREFIX)/lib
 INCLUDEDIR   := $(PREFIX)/include
-INSTALL	 := install
+INSTALL      := install
 
 # Compilation tools
 HOSTCC       := $(prefix)gcc
@@ -73,6 +73,16 @@ AR           := $(prefix)$(CROSS_COMPILE)ar
 RANLIB       := $(prefix)$(CROSS_COMPILE)ranlib
 OBJCOPY      := $(prefix)$(CROSS_COMPILE)objcopy
 
+# Set verbose or nonverbose output similarly to automake's silent rules.
+# Default is nonverbose, but, just like with automake, it can be disabled
+# with: 'make V=1'
+ifneq ($(V),1)
+  HIDE=@
+  ECHO=echo
+else
+  HIDE=
+  ECHO=true
+endif
 
 # Host/target identification
 OS           := $(shell uname -s)
@@ -205,9 +215,13 @@ CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wno-pointer-sign -Werror \
            $(if $(findstring gcc,$(CC)),-fno-merge-all-constants,)
 endif
 
+ifeq ($(V),1)
 ARFLAGS := rDv
+else
+ARFLAGS := rD
+endif
 ASFLAGS += $(ARCH3264)
-LDFLAGS	+= -nostdlib 
+LDFLAGS += -nostdlib 
 ifeq ($(IS_MINGW32),)
   LDFLAGS += --warn-common --no-undefined --fatal-warnings \
              --build-id=sha1 -z nocombreloc -z norelro

--- a/Make.rules
+++ b/Make.rules
@@ -38,34 +38,43 @@
 
 ifeq ($(IS_MINGW32),)
 %.efi: %.so
-	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .rodata -j .rel \
+	@$(ECHO) "  OBJCOPY  $(notdir $@)"
+	$(HIDE)$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .rodata -j .rel \
 		    -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
 		    -j .areloc -j .reloc $(FORMAT) $*.so $@
 
 %.efi.debug: %.so
-	$(OBJCOPY) -j .debug_info -j .debug_abbrev -j .debug_aranges \
+	@$(ECHO) "  OBJCOPY  $(notdir $@)"
+	$(HIDE)$(OBJCOPY) -j .debug_info -j .debug_abbrev -j .debug_aranges \
 		-j .debug_line -j .debug_str -j .debug_ranges \
 		-j .note.gnu.build-id \
 		$(FORMAT) $*.so $@
 
 %.so: %.o
-	$(LD) $(LDFLAGS) $^ -o $@ $(LOADLIBES)
+	@$(ECHO) "  LD       $(notdir $@)"
+	$(HIDE)$(LD) $(LDFLAGS) $^ -o $@ $(LOADLIBES)
 else
 %.efi: %.o
-	$(CC) $(LDFLAGS) $< -o $@ $(LOADLIBES)
+	@$(ECHO) "  CCLD     $(notdir $@)"
+	$(HIDE)$(CC) $(LDFLAGS) $< -o $@ $(LOADLIBES)
 endif
 
 %.o: %.c
-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	@$(ECHO) "  CC       $(notdir $@)"
+	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 %.s: %.c
-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -S $< -o $@
+	@$(ECHO) "  CC       $(notdir $@)"
+	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -S $< -o $@
 
 %.i: %.c
-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -E $< -o $@
+	@$(ECHO) "  CPP      $(notdir $@)"
+	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -E $< -o $@
 
 %.o: %.S
-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	@$(ECHO) "  CC       $(notdir $@)"
+	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 %.s: %.S
-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -E $< -o $@
+	@$(ECHO) "  CPP      $(notdir $@)"
+	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -E $< -o $@

--- a/gnuefi/Makefile
+++ b/gnuefi/Makefile
@@ -85,10 +85,12 @@ TARGETS	= crt0-efi-$(ARCH).o libgnuefi.a
 all:	$(TARGETS) gnu-efi.pc
 
 libgnuefi.a: $(OBJS)
-	$(AR) $(ARFLAGS) $@ $^
+	@$(ECHO) "  AR       $(notdir $@)"
+	$(HIDE)$(AR) $(ARFLAGS) $@ $^
 
 gnu-efi.pc:
-	sed \
+	@$(ECHO) "  GEN      $(notdir $@)"
+	$(HIDE)sed \
 		-e 's:@PREFIX@:$(PREFIX):g' \
 		-e 's:@EXEC_PREFIX@:$(EXEC_PREFIX):g' \
 		-e 's:@INCLUDEDIR@:$(INCLUDEDIR):g' \

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -43,9 +43,9 @@ include $(SRCDIR)/../Make.defaults
 
 FILES = boxdraw smbios console crc data debug dpath \
         entry error event exit guid hand hw init lock \
-        misc pause print sread str cmdline\
-	runtime/rtlock runtime/efirtlib runtime/rtstr runtime/vm runtime/rtdata  \
-	$(ARCH)/initplat $(ARCH)/math $(ARCH)/setjmp
+        misc pause print sread str cmdline runtime/rtlock \
+        runtime/efirtlib runtime/rtstr runtime/vm runtime/rtdata \
+        $(ARCH)/initplat $(ARCH)/math $(ARCH)/setjmp
 
 ifeq ($(ARCH),ia64)
 FILES += $(ARCH)/salpal $(ARCH)/palproc
@@ -75,7 +75,8 @@ libsubdirs:
 $(OBJS): libsubdirs
 
 libefi.a: $(OBJS)
-	$(AR) $(ARFLAGS) $@ $^
+	@$(ECHO) "  AR       $(notdir $@)"
+	$(HIDE)$(AR) $(ARFLAGS) $@ $^
 
 clean:
 	@rm -vf libefi.a *~ $(OBJS) */*.o


### PR DESCRIPTION
This branch adds two mostly unrelated patches.

The first one sets the compilation to produce output similar to the one generated with automake/libtools when enabling silent rules, namely something like:
```
make[1]: Entering directory '/home/runner/work/gnu-efi/gnu-efi/x86_64/apps'
  CC       t.o
  LD       t.so
  OBJCOPY  t.efi
  CC       t2.o
  LD       t2.so
  OBJCOPY  t2.efi
  CC       t3.o
  LD       t3.so
  OBJCOPY  t3.efi
  CC       t4.o
  LD       t4.so
  OBJCOPY  t4.efi
  (etc...)
```
This makes any warning or error much easier to locate as it'll instantly pop out. But of course, this is done at the expense of verbosity. Just as with the silent rules of automake however, the old verbose behaviour can be restored by adding `V=1` when invoking `make`.

The second patch adds RISCV64 testing, using the unmodified `RISCV_VIRT_CODE.fd` firmware image from http://ftp.ie.debian.org/debian/pool/main/e/edk2/qemu-efi-riscv64_2024.02-2_all.deb (which again I am repackaging at https://efi.akeo.ie as the package link can and will be changed with new Debian releases).

Note that this requires running on Ubuntu 24.04 (rather than Ubuntu 22.04, [which is what `ubuntu-latest` from GitHub Actions currently still maps to](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)), as this will only work with QEMU 8.2 or later.

I also had a patch that added `dr0.efi` testing to our tests, but unfortunately, as long as #27 is not resolved, this cannot be added as the test will fail on RISCV64...