### PR TITLE
Fix double reference to route80h.efi in apps

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -65,13 +65,13 @@ LDFLAGS		+= -shared -Bsymbolic -L$(TOPDIR)/$(ARCH)/lib
 LOADLIBES	+= -lefi $(CRT0_LIBS)
 LOADLIBES	+= $(LIBGCC)
 
-TARGET_APPS = t.efi t2.efi t3.efi t4.efi t5.efi t6.efi t7.efi t8.efi \
-	      tcc.efi printenv.efi modelist.efi route80h.efi route80h.efi \
-	      drv0_use.efi AllocPages.efi exit.efi FreePages.efi bltgrid.efi \
-	      lfbgrid.efi setdbg.efi unsetdbg.efi old_ABI.efi
+TARGET_APPS  = t.efi t2.efi t3.efi t4.efi t5.efi t6.efi t7.efi t8.efi \
+               tcc.efi printenv.efi modelist.efi route80h.efi drv0_use.efi \
+               AllocPages.efi exit.efi FreePages.efi bltgrid.efi \
+               lfbgrid.efi setdbg.efi unsetdbg.efi old_ABI.efi
 ifeq ($(IS_MINGW32),)
 TARGET_APPS += setjmp.efi debughook.efi debughook.efi.debug \
-	      ctors_test.efi ctors_dtors_priority_test.efi
+               ctors_test.efi ctors_dtors_priority_test.efi
 endif
 
 TARGET_BSDRIVERS = drv0.efi


### PR DESCRIPTION
Commit 625bdb6368d80ff048a2fcdb91023f9a9d5a4ca0 reorganized the apps list but also duplicated `route80h.efi` so remove the extra one, as having two instances produces an error when running `make install`.