### PR TITLE
Fix driver EFI subsystem for VS and RISCV64 and add driver testing

### DIFF
--- a/.vs/apps/drv0.vcxproj
+++ b/.vs/apps/drv0.vcxproj
@@ -7,6 +7,46 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>drv0</ProjectName>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Link>
+      <SubSystem>EFI Boot Service Driver</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\apps\drv0.c" />
   </ItemGroup>

--- a/Make.rules
+++ b/Make.rules
@@ -36,12 +36,17 @@
 
 .SECONDARY:
 
+CHAR_SUBSYSTEM=$(subst 0x,\x,$(SUBSYSTEM))
+
 ifeq ($(IS_MINGW32),)
 %.efi: %.so
 	@$(ECHO) "  OBJCOPY  $(notdir $@)"
 	$(HIDE)$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .rodata -j .rel \
 		    -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
 		    -j .areloc -j .reloc $(FORMAT) $*.so $@
+ifeq ($(ARCH),riscv64)
+	$(HIDE)/bin/echo -ne "$(CHAR_SUBSYSTEM)" | dd of=$@ bs=1 seek=156 count=1 conv=notrunc status=none
+endif
 
 %.efi.debug: %.so
 	@$(ECHO) "  OBJCOPY  $(notdir $@)"

--- a/gnuefi/crt0-efi-riscv64.S
+++ b/gnuefi/crt0-efi-riscv64.S
@@ -16,10 +16,6 @@
  * either version 2 of the License, or (at your option) any later version.
  */
 
-#ifndef EFI_SUBSYSTEM
-#define EFI_SUBSYSTEM 10
-#endif
-
 	.section	.text.head
 
 	/*
@@ -71,7 +67,7 @@ extra_header_fields:
 	// Everything before the kernel image is considered part of the header
 	.4byte	_text - ImageBase		// SizeOfHeaders
 	.4byte	0				// CheckSum
-	.2byte	EFI_SUBSYSTEM			// Subsystem
+	.2byte	0				// Subsystem
 	.2byte	0				// DllCharacteristics
 	.8byte	0				// SizeOfStackReserve
 	.8byte	0				// SizeOfStackCommit

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -5,7 +5,7 @@
 > echo "reset -s" >> $UEFI_DIR/startup.nsh
 Hello World!
 Hello World!
-< rm $UEFI_DIR/t.efi
+< rm $UEFI_DIR/*.efi
 
 # Test args
 > cp tcc.efi $UEFI_DIR
@@ -25,7 +25,7 @@ Returning Failure works
 8 args works just fine here.
 9 args works just fine here.
 10 args works just fine here.
-< rm $UEFI_DIR/tcc.efi
+< rm $UEFI_DIR/*.efi
 
 # Print args
 > cp t8.efi $UEFI_DIR
@@ -37,4 +37,15 @@ Hello World, started with Argc=3
   Argv[1] = 'Test1'
   Argv[2] = 'Test2'
 Bye.
-< rm $UEFI_DIR/t8.efi
+< rm $UEFI_DIR/*.efi
+
+# Test driver
+> cp drv0.efi drv0_use.efi $UEFI_DIR
+> echo "@echo -off" > $UEFI_DIR/startup.nsh
+> echo "load FS0:\drv0.efi" >> $UEFI_DIR/startup.nsh
+> echo "FS0:\drv0_use.efi" >> $UEFI_DIR/startup.nsh
+> echo "reset -s" >> $UEFI_DIR/startup.nsh
+Playing with driver instance 0...
+Hello Sample UEFI Driver!
+Hello was called 1 time(s).
+< rm $UEFI_DIR/*.efi


### PR DESCRIPTION
This series of patches aims at adding driver testing to our test suite.

To accomplish that, we need to fix the subsystem that was improperly set for the Visual Studio driver, as well as fix subsystem generation for RISCV64, which was broken per #27.

To accomplish the latter, we simply set the subsystem using `dd` after the `objcopy` step (which is made a little more complex due to the fact that GNU Make's echo doesn't support `-ne` but still relatively straightforward).

With these patches, we can then add a new test that validates that `drv0` loads and can be invoked.