### PR TITLE
Apply stdbool/stdint MSVC fixes

### DIFF
--- a/inc/efidef.h
+++ b/inc/efidef.h
@@ -35,6 +35,9 @@ typedef bool BOOLEAN;
 #endif
 #ifndef TRUE
 #if defined(__cplusplus) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#if defined(_MSC_VER)
+#include <stdbool.h>
+#endif
     #define TRUE    true
     #define FALSE   false
 #else

--- a/inc/ia32/efibind.h
+++ b/inc/ia32/efibind.h
@@ -77,7 +77,7 @@ Revision History
     #endif
     typedef uint32_t            uintptr_t;
     typedef int32_t             intptr_t;
-#elif defined(__GNUC__)
+#else
     #include <stdint.h>
 #endif
 

--- a/inc/ia64/efibind.h
+++ b/inc/ia64/efibind.h
@@ -64,7 +64,7 @@ Revision History
     #endif
     typedef uint64_t            uintptr_t;
     typedef int64_t             intptr_t;
-#elif defined(__GNUC__)
+#else
     #include <stdint.h>
 #endif
 


### PR DESCRIPTION
It seems that while Visual Studio can support the C23 standard, Microsoft didn't get the memo about no longer requiring `stdbool.h` for `true`/`false`, so add an exception for that.

Also harmonize the inclusion of `stdint.h` for IA32 and IA64 so that, just like for other archs, it is not limited to GNU-like compilers only.