### PR TITLE
Add MP Services Protocol Support

### DIFF
--- a/inc/efi.h
+++ b/inc/efi.h
@@ -82,6 +82,7 @@ extern "C" {
 #include "efifs.h"
 #include "efierr.h"
 #include "efiui.h"
+#include "efimp.h"
 #include "efiip.h"
 #include "efiudp.h"
 #include "efitcp.h"

--- a/inc/efilib.h
+++ b/inc/efilib.h
@@ -135,6 +135,9 @@ extern EFI_GUID gEfiDriverFamilyOverrideProtocolGuid;
 #define DriverFamilyOverrideProtocol gEfiDriverFamilyOverrideProtocolGuid
 extern EFI_GUID gEfiEbcProtocolGuid;
 
+extern EFI_GUID gEfiMpServicesProtocolGuid;
+#define MpServicesProtocol gEfiMpServicesProtocolGuid
+
 extern EFI_GUID gEfiGlobalVariableGuid;
 #define EfiGlobalVariable gEfiGlobalVariableGuid
 extern EFI_GUID gEfiFileInfoGuid;

--- a/inc/efimp.h
+++ b/inc/efimp.h
@@ -1,0 +1,137 @@
+#ifndef _EFI_MP_H
+#define _EFI_MP_H
+
+
+
+#define EFI_MP_SERVICES_PROTOCOL_GUID \
+    { 0x3fdda605, 0xa76e, 0x4f46, {0xad, 0x29, 0x12, 0xf4, 0x53, 0x1b, 0x3d, 0x08} }
+
+#define PROCESSOR_AS_BSP_BIT        (1 << 0)
+#define PROCESSOR_ENABLED_BIT       (1 << 1)
+#define PROCESSOR_HEALTH_STATUS_BIT (1 << 2)
+
+INTERFACE_DECL(_EFI_MP_SERVICES_PROTOCOL);
+
+
+typedef
+struct {
+    UINT32  Package;
+    UINT32  Core;
+    UINT32  Thread;
+} EFI_CPU_PHYSICAL_LOCATION;
+
+typedef
+struct {
+    UINT32  Package;
+    UINT32  Module;
+    UINT32  Tile;
+    UINT32  Die;
+    UINT32  Core;
+    UINT32  Thread;
+} EFI_CPU_PHYSICAL_LOCATION2;
+
+typedef
+union {
+    EFI_CPU_PHYSICAL_LOCATION2  Location2;
+} EXTENDED_PROCESSOR_INFORMATION;
+
+
+typedef
+struct {
+    UINT64                          ProcessorId;
+    UINT32                          StatusFlag;
+    EFI_CPU_PHYSICAL_LOCATION       Location;
+    EXTENDED_PROCESSOR_INFORMATION ExtendedInformation;
+} EFI_PROCESSOR_INFORMATION;
+
+
+typedef
+VOID
+(EFIAPI *EFI_AP_PROCEDURE) (
+    IN VOID *ProcedureArgument
+);
+
+
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_GET_NUMBER_OF_PROCESSORS) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    OUT UINTN                           *NumberOfProcessors,
+    OUT UINTN                           *NumberOfEnabledProcessors
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_GET_PROCESSOR_INFO) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    IN UINTN                            ProcessorNumber,
+    OUT EFI_PROCESSOR_INFORMATION       *ProcessorInfoBuffer
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_STARTUP_ALL_APS) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    IN EFI_AP_PROCEDURE                 Procedure,
+    IN BOOLEAN                          SingleThread,
+    IN EFI_EVENT                        WaitEvent               OPTIONAL,
+    IN UINTN                            TimeoutInMicroseconds,
+    IN VOID                             *ProcedureArgument      OPTIONAL,
+    OUT UINTN                           **FailedCpuList         OPTIONAL
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_STARTUP_THIS_AP) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    IN EFI_AP_PROCEDURE                 Procedure,
+    IN UINTN                            ProcessorNumber,
+    IN EFI_EVENT                        WaitEvent               OPTIONAL,
+    IN UINTN                            TimeoutInMicroseconds,
+    IN VOID                             *ProcedureArgument      OPTIONAL,
+    OUT BOOLEAN                         *Finished               OPTIONAL
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_SWITCH_BSP) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    IN UINTN                            ProcessorNumber,
+    IN BOOLEAN                          EnableOldBSP
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_ENABLEDISABLEAP) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    IN UINTN                            ProcessorNumber,
+    IN BOOLEAN                          EnableAP,
+    IN UINT32                           *HealthFlag     OPTIONAL
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_MP_SERVICES_WHOAMI) (
+    IN struct _EFI_MP_SERVICES_PROTOCOL *This,
+    OUT UINTN                           *ProcessorNumber
+);
+
+
+/**
+ * The primary protocol structure for MP service methods.
+ */
+typedef
+struct _EFI_MP_SERVICES_PROTOCOL {
+    EFI_MP_SERVICES_GET_NUMBER_OF_PROCESSORS    GetNumberOfProcessors;
+    EFI_MP_SERVICES_GET_PROCESSOR_INFO          GetProcessorInfo;
+    EFI_MP_SERVICES_STARTUP_ALL_APS             StartupAllAPs;
+    EFI_MP_SERVICES_STARTUP_THIS_AP             StartupThisAP;
+    EFI_MP_SERVICES_SWITCH_BSP                  SwitchBSP;
+    EFI_MP_SERVICES_ENABLEDISABLEAP             EnableDisableAP;
+    EFI_MP_SERVICES_WHOAMI                      WhoAmI;
+} EFI_MP_SERVICES_PROTOCOL;
+
+
+
+#endif   /* _EFI_MP_H */

--- a/inc/inc.mak
+++ b/inc/inc.mak
@@ -10,6 +10,7 @@ INC_DEPS = $(INC_DEPS)          \
                 efidevp.h       \
                 efierr.h        \
                 efifs.h         \
+                efimp.h         \
                 efilib.h        \
                 efipart.h       \
                 efipciio.h      \

--- a/inc/make.inf
+++ b/inc/make.inf
@@ -11,6 +11,7 @@
     efidevp.h
     efierr.h
     efifs.h
+    efimp.h
     efilib.h
     efipart.h
     efipciio.h

--- a/inc/makefile.hdr
+++ b/inc/makefile.hdr
@@ -15,6 +15,7 @@ INC_DEPS = $(INC_DEPS) \
     $(SDK_INSTALL_DIR)\include\efi\efidevp.h \
     $(SDK_INSTALL_DIR)\include\efi\efierr.h \
     $(SDK_INSTALL_DIR)\include\efi\efifs.h \
+    $(SDK_INSTALL_DIR)\include\efi\efimp.h \
     $(SDK_INSTALL_DIR)\include\efi\efilib.h \
     $(SDK_INSTALL_DIR)\include\efi\efipart.h \
     $(SDK_INSTALL_DIR)\include\efi\efipciio.h \

--- a/lib/data.c
+++ b/lib/data.c
@@ -133,6 +133,11 @@ EFI_GUID gEfiFileSystemInfoGuid                     = EFI_FILE_SYSTEM_INFO_ID;
 EFI_GUID gEfiFileSystemVolumeLabelInfoIdGuid        = EFI_FILE_SYSTEM_VOLUME_LABEL_ID;
 
 //
+// Multi-Processing protocol IDs.
+//
+EFI_GUID gEfiMpServicesProtocolGuid                 = EFI_MP_SERVICES_PROTOCOL_GUID;
+
+//
 // Reference implementation public protocol IDs
 //
 

--- a/lib/guid.c
+++ b/lib/guid.c
@@ -66,6 +66,8 @@ static struct {
 	{  &gEfiComponentNameProtocolGuid,                  u"CName" },
 	{  &gEfiComponentName2ProtocolGuid,                 u"CName2" },
 
+    {  &gEfiMpServicesProtocolGuid,                     u"Mp" },
+
 	{  &gEfiFileInfoGuid,                               u"FileInfo" },
 	{  &gEfiFileSystemInfoGuid,                         u"FsInfo" },
 	{  &gEfiFileSystemVolumeLabelInfoIdGuid,            u"FsVolInfo" },


### PR DESCRIPTION
See [Sections 13.3 and 13.4](https://uefi.org/specs/PI/1.8A/V2_DXE_Boot_Services_Protocols.html#mp-services-protocol-overview) of the UEFI PI Specification.

Many of the definitions here are taken from the UEFI spec, but they [show up similarly in EDK2](https://github.com/tianocore/edk2/blob/master/MdePkg/Include/Protocol/MpService.h) as well.

This intends to add integral support of the MP services protocol for applications using the `gnu-efi` library.