### PR TITLE
Replace /bin/env with /usr/bin/env

### DIFF
--- a/tests/gen_tests.sh
+++ b/tests/gen_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 ## @file
 #  Test generation script for gnu-efi.
@@ -24,13 +24,13 @@ while IFS=$'\r\n' read -r line; do
     teardown_file=$(printf "%s/%03d teardown.sh" $TEST_DIR $test_number)
   elif [[ ${line:0:1} == ">" ]]; then
     if [[ ! -f "$setup_file" ]]; then
-      echo "#!/bin/env bash" > "$setup_file"
+      echo "#!/usr/bin/env bash" > "$setup_file"
       chmod 755 "$setup_file"
     fi
     echo "${line:2}" >> "$setup_file"
   elif [[ ${line:0:1} == "<" ]]; then
     if [[ ! -f "$teardown_file" ]]; then
-      echo "#!/bin/env bash" > "$teardown_file"
+      echo "#!/usr/bin/env bash" > "$teardown_file"
       chmod 755 "$teardown_file"
     fi
     echo "${line:2}" >> "$teardown_file"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 ## @file
 #  Test script for gnu-efi.


### PR DESCRIPTION
The correct path for the env binary on systems without a usr-merge is `/usr/bin/env`.