### PR TITLE
Align CRT0 exit function naming

### DIFF
--- a/gnuefi/crt0-efi-aarch64-local.S
+++ b/gnuefi/crt0-efi-aarch64-local.S
@@ -161,12 +161,13 @@ _start:
 	adrp		x1, _DYNAMIC
 	add		x1, x1, #:lo12:_DYNAMIC
 	bl		_relocate
-	cbnz		x0, 0f
+	cbnz		x0, .L_exit
 
 	ldp		x0, x1, [sp, #16]
 	bl		_entry
 
-0:	ldp		x29, x30, [sp], #32
+.L_exit:
+	ldp		x29, x30, [sp], #32
 	ret
 
 	// hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:

--- a/gnuefi/crt0-efi-aarch64.S
+++ b/gnuefi/crt0-efi-aarch64.S
@@ -32,16 +32,17 @@ _start:
 	adrp		x1, _DYNAMIC
 	add		x1, x1, #:lo12:_DYNAMIC
 	bl		_relocate
-	cbnz		x0, 0f
+	cbnz		x0, .L_exit
 
 	ldp		x0, x1, [sp, #16]
 	bl		_entry
 
-0:	ldp		x29, x30, [sp], #32
+.L_exit:
+	ldp		x29, x30, [sp], #32
 	ret
 
 	// hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:
- 
+
  	.data
 dummy0:	.4byte	0
 dummy1:	.4byte	0

--- a/gnuefi/crt0-efi-arm.S
+++ b/gnuefi/crt0-efi-arm.S
@@ -163,12 +163,13 @@ _start:
 	sub		r0, r0, #0x1000
 	bl		_relocate
 	teq		r0, #0
-	bne		0f
+	bne		.L_exit
 
 	ldmfd		sp, {r0-r1}
 	bl		_entry
 
-0:	add		sp, sp, #12
+.L_exit:
+	add		sp, sp, #12
 	ldr		pc, [sp], #4
 
 .L_DYNAMIC:

--- a/gnuefi/crt0-efi-ia32-local.S
+++ b/gnuefi/crt0-efi-ia32-local.S
@@ -153,11 +153,12 @@ _start:
 	popl %ebx
 	popl %ebx
 	testl %eax,%eax
-	jne .exit
+	jne .L_exit
   
 	call _entry			# call app with "image" and "systab" argument
 
-.exit:	leave
+.L_exit:
+	leave
 	ret
 
 // hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:

--- a/gnuefi/crt0-efi-ia32.S
+++ b/gnuefi/crt0-efi-ia32.S
@@ -58,11 +58,12 @@ _start:
 	popl %ebx
 	popl %ebx
 	testl %eax,%eax
-	jne .exit
+	jne .L_exit
   
 	call _entry			# call app with "image" and "systab" argument
 
-.exit:	leave
+.L_exit:
+	leave
 	ret
  
  	// hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:

--- a/gnuefi/crt0-efi-loongarch64.S
+++ b/gnuefi/crt0-efi-loongarch64.S
@@ -32,13 +32,14 @@ _start:
 	la.local  $a0, ImageBase	// a0: ImageBase
 	la.local  $a1, _DYNAMIC		// a1: DynamicSection
 	bl        _relocate
-	bnez	  $a0, 0f
+	bnez	  $a0, .L_exit
 
 	ld.d	  $a0, $sp, 8
 	ld.d	  $a1, $sp, 16
 	bl        _entry
 
-0:	ld.d	  $ra, $sp, 0
+.L_exit:
+	ld.d	  $ra, $sp, 0
 	addi.d	  $sp, $sp, 24
 	jr	      $ra
 

--- a/gnuefi/crt0-efi-riscv64-local.S
+++ b/gnuefi/crt0-efi-riscv64-local.S
@@ -159,12 +159,13 @@ _start:
 	lla		a0, ImageBase
 	lla		a1, _DYNAMIC
 	call		_relocate
-	bne		a0, zero, 0f
+	bne		a0, zero, .L_exit
 	ld		a1, 8(sp)
 	ld		a0, 0(sp)
 	call		_entry
 	ld		ra, 16(sp)
-0:	addi		sp, sp, 24
+.L_exit:
+	addi		sp, sp, 24
 	ret
 
 // hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:

--- a/gnuefi/crt0-efi-riscv64.S
+++ b/gnuefi/crt0-efi-riscv64.S
@@ -27,12 +27,13 @@ _start:
 	lla		a0, ImageBase
 	lla		a1, _DYNAMIC
 	call		_relocate
-	bne		a0, zero, 0f
+	bne		a0, zero, .L_exit
 	ld		a1, 8(sp)
 	ld		a0, 0(sp)
 	call		_entry
 	ld		ra, 16(sp)
-0:	addi		sp, sp, 24
+.L_exit:
+	addi		sp, sp, 24
 	ret
 
 // hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:

--- a/gnuefi/crt0-efi-x86_64.S
+++ b/gnuefi/crt0-efi-x86_64.S
@@ -60,7 +60,7 @@ _start:
 	call _entry
 	addq $8, %rsp
 
-.exit:	
+.L_exit:	
   	ret
 
  	// hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:


### PR DESCRIPTION
Align it to .L_exit
Also more useful as a local symbol than a non descriptive local label