### PR TITLE
Add ms_abi va_list support

### DIFF
--- a/inc/efistdarg.h
+++ b/inc/efistdarg.h
@@ -19,15 +19,50 @@ Revision History
 
 --*/
 
-#if !defined(GNU_EFI_USE_EXTERNAL_STDARG) && !defined(_MSC_VER)
-typedef __builtin_va_list va_list;
-
-# define va_start(v,l)	__builtin_va_start(v,l)
-# define va_end(v)	__builtin_va_end(v)
-# define va_arg(v,l)	__builtin_va_arg(v,l)
-# define va_copy(d,s)	__builtin_va_copy(d,s)
+/* Use somebody else's definitions */
+#if defined(GNU_EFI_USE_EXTERNAL_STDARG)
+#include <stdarg.h>
 #else
-# include <stdarg.h>
+
+/* MSVC */
+#if defined(_MSC_VER)
+#include <stdarg.h>
+typedef va_list ms_va_list;
+#define ms_va_start(v,l) va_start(v,l)
+#define ms_va_end(v) va_end(v)
+#define ms_va_arg(v,l) va_arg(v,l)
+#define ms_va_copy(d,s) va_copy(d,s)
 #endif
 
+/* GCC x86_64 */
+#if !defined(_MSC_VER) && defined(__x86_64__)
+typedef __builtin_va_list va_list;
+#define va_start(v,l) __builtin_va_start(v,l)
+#define va_end(v) __builtin_va_end(v)
+#define va_arg(v,l) __builtin_va_arg(v,l)
+#define va_copy(d,s) __builtin_va_copy(d,s)
+typedef __builtin_ms_va_list ms_va_list;
+#define ms_va_start(v,l) __builtin_ms_va_start(v,l)
+#define ms_va_end(v) __builtin_ms_va_end(v)
+#define ms_va_arg(v,l) __builtin_va_arg(v,l) /* There is no __builtin_ms_va_arg */
+#define ms_va_copy(d,s) __builtin_ms_va_copy(d,s)
+#endif
+
+/* GCC non-x86_64 */
+#if !defined(_MSC_VER) && !defined(__x86_64__)
+typedef __builtin_va_list va_list;
+#define va_start(v,l) __builtin_va_start(v,l)
+#define va_end(v) __builtin_va_end(v)
+#define va_arg(v,l) __builtin_va_arg(v,l)
+#define va_copy(d,s) __builtin_va_copy(d,s)
+typedef __builtin_va_list ms_va_list;
+#define ms_va_start(v,l) __builtin_va_start(v,l)
+#define ms_va_end(v) __builtin_va_end(v)
+#define ms_va_arg(v,l) __builtin_va_arg(v,l)
+#define ms_va_copy(d,s) __builtin_va_copy(d,s)
+#endif
+
+
+
+#endif
 #endif


### PR DESCRIPTION
Support for variadic args on EFIAPI functions only differs on x86_64, although this will change when we get ms_abi on aarch64