### PR TITLE
Avoid integer promotion bug in memory functions

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -260,9 +260,9 @@ CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Werror \
            -fno-strict-aliasing \
            -ffreestanding -fno-stack-protector
 else
-CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wno-pointer-sign -Werror \
+CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Werror \
            -fno-strict-aliasing \
-           -ffreestanding -fno-stack-protector -fno-stack-check \
+           -ffreestanding -fno-stack-protector \
            $(if $(findstring 0,$(USING_CLANG)),-Wno-error=maybe-uninitialized,) \
            $(if $(findstring 0,$(USING_CLANG)),-fno-merge-all-constants,)
 endif

--- a/lib/runtime/efirtlib.c
+++ b/lib/runtime/efirtlib.c
@@ -30,7 +30,7 @@ RtZeroMem (
     IN UINTN     Size
     )
 {
-    INT8        *pt;
+    UINT8        *pt;
 
     pt = Buffer;
     while (Size--) {
@@ -50,7 +50,7 @@ RtSetMem (
     IN UINT8    Value
     )
 {
-    INT8        *pt;
+    UINT8        *pt;
 
     pt = Buffer;
     while (Size--) {
@@ -70,8 +70,10 @@ RtCopyMem (
     IN UINTN       len
     )
 {
-    CHAR8 *d = (CHAR8*)Dest;
-    CHAR8 *s = (CHAR8*)Src;
+    UINT8 *d, *s;
+
+    d = Dest;
+    s = Src;
 
     if (d == NULL || s == NULL || s == d)
         return;
@@ -118,7 +120,11 @@ RtCompareMem (
     IN UINTN    len
     )
 {
-    CONST CHAR8    *d = Dest, *s = Src;
+    CONST UINT8 *d, *s;
+
+    d = Dest;
+    s = Src;
+
     while (len--) {
         if (*d != *s) {
             return *d - *s;
@@ -157,14 +163,14 @@ Returns:
 
 --*/
 {
-    INT32       *g1, *g2, r;
+    UINT32       *g1, *g2, r;
 
     //
     // Compare 32 bits at a time
     //
 
-    g1 = (INT32 *) Guid1;
-    g2 = (INT32 *) Guid2;
+    g1 = (UINT32*)Guid1;
+    g2 = (UINT32*)Guid2;
 
     r  = g1[0] - g2[0];
     r |= g1[1] - g2[1];

--- a/lib/runtime/efirtlib.c
+++ b/lib/runtime/efirtlib.c
@@ -137,6 +137,9 @@ RtCompareMem (
     return 0;
 }
 
+
+typedef UINT32 QUAD_UINT32[4]; /* EFI_GUID is 128 bits so 32 x 4 */
+
 #ifndef __GNUC__
 #pragma RUNTIME_CODE(RtCompareGuid)
 #endif
@@ -151,7 +154,7 @@ RtCompareGuid (
 
 Routine Description:
 
-    Compares to GUIDs
+    Compares two GUIDs
 
 Arguments:
 
@@ -163,19 +166,20 @@ Returns:
 
 --*/
 {
-    UINT32       *g1, *g2, r;
+    CONST QUAD_UINT32 *g1, *g2;
+    UINT32 r;
 
     //
     // Compare 32 bits at a time
     //
 
-    g1 = (UINT32*)Guid1;
-    g2 = (UINT32*)Guid2;
+    g1 = (CONST QUAD_UINT32*)Guid1;
+    g2 = (CONST QUAD_UINT32*)Guid2;
 
-    r  = g1[0] - g2[0];
-    r |= g1[1] - g2[1];
-    r |= g1[2] - g2[2];
-    r |= g1[3] - g2[3];
+    r  = (*g1)[0] - (*g2)[0];
+    r |= (*g1)[1] - (*g2)[1];
+    r |= (*g1)[2] - (*g2)[2];
+    r |= (*g1)[3] - (*g2)[3];
 
     if (r==0) {
         return 1;


### PR DESCRIPTION
Most of this would have been fine anyway since CHAR8 is unsigned char but just in case it gets changed

Based on: rhboot/gnu-efi@7cfefa091903bfde6160f94f52ac66c51f07989f