### PR TITLE
Makefile: Fix wrong prefix when compiling assembly source files

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -79,7 +79,7 @@ endif
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -E $< -o $@
 
 %.o: %.S
-	@$(ECHO) "  CC       $(notdir $@)"
+	@$(ECHO) "  AS       $(notdir $@)"
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -c $< -o $@
 
 %.s: %.S


### PR DESCRIPTION
When compiling with style like "CC foo.o" assembly source files are being used with wrong prefix( which is CC). This may result confusion of which object file was assembly and which was C.

Project that use this design for compiling like linux kernel use "AS" to indicate the object file being compiled is assembly.

Chnage the prefix for assembly files to "AS" to indicate object being assembled is assembly file.