### PR TITLE
efibind: fix stdint.h #if operator precedence

### DIFF
--- a/inc/ia32/efibind.h
+++ b/inc/ia32/efibind.h
@@ -25,7 +25,7 @@ Revision History
 // Basic int types of various widths
 //
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L ) && !defined(__cplusplus)
+#if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L )) && !defined(__cplusplus)
 
     // No ANSI C 1999/2000 stdint.h integer width declarations 
 

--- a/inc/ia64/efibind.h
+++ b/inc/ia64/efibind.h
@@ -24,7 +24,7 @@ Revision History
 // Basic int types of various widths
 //
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L ) && !defined(__cplusplus)
+#if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L )) && !defined(__cplusplus)
 
     // No ANSI C 1999/2000 stdint.h integer width declarations 
 

--- a/inc/loongarch64/efibind.h
+++ b/inc/loongarch64/efibind.h
@@ -19,7 +19,7 @@
  * either version 2 of the License, or (at your option) any later version.
  */
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L ) && !defined(__cplusplus)
+#if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L )) && !defined(__cplusplus)
 
 // ANSI C 1999/2000 stdint.h integer width declarations
 

--- a/inc/mips64el/efibind.h
+++ b/inc/mips64el/efibind.h
@@ -17,7 +17,7 @@
  * either version 2 of the License, or (at your option) any later version.
  */
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L ) && !defined(__cplusplus)
+#if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L )) && !defined(__cplusplus)
 
 // ANSI C 1999/2000 stdint.h integer width declarations
 

--- a/inc/x86_64/efibind.h
+++ b/inc/x86_64/efibind.h
@@ -36,7 +36,7 @@ Revision History
 // Basic int types of various widths
 //
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L ) && !defined(__cplusplus)
+#if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L )) && !defined(__cplusplus)
 
     // No ANSI C 1999/2000 stdint.h integer width declarations 
 


### PR DESCRIPTION
This PR fixes the operator precedence of the #if/#else for including `stdint.h` in efibind.h. This fix is applied to `x86_64`, `mips64el`, `loongarch64`, `ia64` and `ia32`. `aarch64` and `arm` already have the correct operator precedence.