### PR TITLE
Make.defaults: disable LSX/LASX for loongarch64 EFI code

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -204,6 +204,10 @@ ifeq ($(ARCH),mips64el)
   ARCH3264 = -mabi=64
 endif
 
+ifeq ($(ARCH),loongarch64)
+EFI_CFLAGS += -mno-lsx -mno-lasx
+endif
+
 #
 # Set HAVE_EFI_OBJCOPY if objcopy understands --target efi-[app|bsdrv|rtdrv],
 # otherwise we need to compose the PE/COFF header using the assembler


### PR DESCRIPTION
This prevents LoongArch64 gnu-efi libraries from carrying LSX/LASX SIMD
instructions into EFI applications.

I found this while building fwupd-efi on LoongArch64. [fwupd-efi](https://github.com/fwupd/fwupd-efi/commit/0595e2b) already adds
-mno-lsx and -mno-lasx for its own objects  but the final fwup.so still
contained LSX instructions because RtCompareGuid was linked from gnu-efi:
```C
  $ llvm-nm -A /usr/lib/libefi.a /usr/lib/libgnuefi.a | grep ' RtCompareGuid'
  /usr/lib/libefi.a:guid.o:                  U RtCompareGuid
  /usr/lib/libefi.a:efirtlib.o: 0000000000000190 T RtCompareGuid

  $ llvm-objdump -d build/efi/fwup.so --start-address=0xc068 --stop-address=0xc0a0
  <RtCompareGuid>:
      vld
      vld
      vsub.w
      vbsrl.v
      vor.v
      vpickve2gr.w
```

UEFI applications should not rely on LoongArch SIMD state being available
or preserved by firmware. When gnu-efi is built with toolchain defaults
that enable LSX or LASX, libefi.a can contain SIMD instructions.
    
One observed case is RtCompareGuid from libefi.a:efirtlib.o being compiled
with LSX instructions such as vld, vsub.w, vbsrl.v, vor.v and
vpickve2gr.w. EFI applications linking against libefi.a then inherit those
instructions even if they disable SIMD in their own build flags.
    
Add -mno-lsx and -mno-lasx for loongarch64 builds to keep the gnu-efi
runtime libraries compatible with baseline LoongArch64 firmware
environments.
    
Reported-by: Zixuan Lu <luzixuan@loongson.cn>
Co-authored-by: Xiaotian Wu <wuxiaotian@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>

