### PR TITLE
Remove the RUNTIME_CODE(), BEGIN_RUNTIME_DATA() and END_RUNTIME_DATA() MSVC macros

### DIFF
--- a/inc/aarch64/efibind.h
+++ b/inc/aarch64/efibind.h
@@ -97,7 +97,6 @@ typedef uint64_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code
 //
 
 #ifndef EFIAPI          // Forces EFI calling conventions reguardless of compiler options
@@ -107,14 +106,7 @@ typedef uint64_t   UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE                volatile
-
 #define MEMORY_FENCE            __sync_synchronize
 
 //

--- a/inc/arm/efibind.h
+++ b/inc/arm/efibind.h
@@ -105,7 +105,6 @@ typedef uint32_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code
 //
 
 #ifndef EFIAPI          // Forces EFI calling conventions reguardless of compiler options
@@ -115,14 +114,7 @@ typedef uint32_t   UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE                volatile
-
 #define MEMORY_FENCE            __sync_synchronize
 
 //

--- a/inc/ia32/efibind.h
+++ b/inc/ia32/efibind.h
@@ -173,7 +173,6 @@ typedef uint32_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code    
 //
 
 #ifndef EFIAPI                  // Forces EFI calling conventions reguardless of compiler options 
@@ -185,19 +184,10 @@ typedef uint32_t   UINTN;
 #endif
 
 #define BOOTSERVICE
-//#define RUNTIMESERVICE(proto,a)    alloc_text("rtcode",a); proto a
-//#define RUNTIMEFUNCTION(proto,a)   alloc_text("rtcode",a); proto a
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE    volatile
-
-#define MEMORY_FENCE()    
+#define MEMORY_FENCE()
 
 #ifdef EFI_NT_EMULATOR
 

--- a/inc/ia64/efibind.h
+++ b/inc/ia64/efibind.h
@@ -152,8 +152,7 @@ typedef uint64_t   UINTN;
 // EFIAPI - prototype calling convention for EFI function pointers
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
-// RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code    
+// RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service 
 //
 
 #ifndef EFIAPI                  // Forces EFI calling conventions reguardless of compiler options 
@@ -167,11 +166,6 @@ typedef uint64_t   UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE    volatile
 
 //
@@ -180,8 +174,8 @@ typedef uint64_t   UINTN;
 #ifdef __GNUC__
 #define MEMORY_FENCE()    __asm__ __volatile__ ("mf.a" ::: "memory")
 #else
-void __mf (void);                       
-#pragma intrinsic (__mf)  
+void __mf (void);
+#pragma intrinsic (__mf)
 #define MEMORY_FENCE()    __mf()
 #endif
 

--- a/inc/internal/print.h
+++ b/inc/internal/print.h
@@ -2,24 +2,8 @@
 #define __GNU_EFI_INTERNAL_PRINT
 
 //
-// Internal fucntions
+// Internal functions
 //
-
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-
-// For debugging..
-
-/*
-#pragma RUNTIME_CODE(PGETC)
-*/
-
-#endif /* !defined(__GNUC__) */
-#endif
 
 typedef struct {
     BOOLEAN             Ascii;
@@ -97,9 +81,3 @@ IsLocalPrint(void *func)
 }
 
 #endif
-
-
-
-//
-//
-//

--- a/inc/internal/va_print.h
+++ b/inc/internal/va_print.h
@@ -27,26 +27,6 @@ typedef va_list VA_LIST;
 #define CALL_CONV
 #endif
 
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-
-// For debugging..
-
-/*
-#pragma RUNTIME_CODE(FUNCTION_NAME(_Print))
-#pragma RUNTIME_CODE(FUNCTION_NAME(PFLUSH))
-#pragma RUNTIME_CODE(FUNCTION_NAME(PSETATTR))
-#pragma RUNTIME_CODE(FUNCTION_NAME(PPUTC))
-#pragma RUNTIME_CODE(FUNCTION_NAME(PITEM))
-*/
-
-#endif /* !defined(__GNUC__) */
-#endif
-
 typedef struct FUNCTION_NAME(_pstate) {
     // Input
     POINTER     fmt;

--- a/inc/loongarch64/efibind.h
+++ b/inc/loongarch64/efibind.h
@@ -101,7 +101,6 @@ typedef uint64_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code
 //
 
 #ifndef EFIAPI          // Forces EFI calling conventions reguardless of compiler options
@@ -111,14 +110,7 @@ typedef uint64_t   UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE                volatile
-
 #define MEMORY_FENCE            __sync_synchronize
 
 //

--- a/inc/mips64el/efibind.h
+++ b/inc/mips64el/efibind.h
@@ -99,7 +99,6 @@ typedef uint64_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code
 //
 
 #ifndef EFIAPI          // Forces EFI calling conventions reguardless of compiler options
@@ -109,14 +108,7 @@ typedef uint64_t   UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE                volatile
-
 #define MEMORY_FENCE            __sync_synchronize
 
 //

--- a/inc/riscv64/efibind.h
+++ b/inc/riscv64/efibind.h
@@ -71,7 +71,6 @@ typedef uint64_t                UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code
 //
 #ifndef EFIAPI                  // Forces EFI calling conventions reguardless of compiler options
 #define EFIAPI                  // Substitute expresion to force C calling convention
@@ -79,10 +78,6 @@ typedef uint64_t                UINTN;
 #define BOOTSERVICE
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE                volatile
 #define MEMORY_FENCE            __sync_synchronize
 

--- a/inc/x86_64/efibind.h
+++ b/inc/x86_64/efibind.h
@@ -183,7 +183,6 @@ typedef uint64_t   UINTN;
 // BOOTSERVICE - prototype for implementation of a boot service interface
 // RUNTIMESERVICE - prototype for implementation of a runtime service interface
 // RUNTIMEFUNCTION - prototype for implementation of a runtime function that is not a service
-// RUNTIME_CODE - pragma macro for declaring runtime code    
 //
 
 #ifndef EFIAPI                  // Forces EFI calling conventions reguardless of compiler options 
@@ -198,19 +197,10 @@ typedef uint64_t   UINTN;
 #endif
 
 #define BOOTSERVICE
-//#define RUNTIMESERVICE(proto,a)    alloc_text("rtcode",a); proto a
-//#define RUNTIMEFUNCTION(proto,a)   alloc_text("rtcode",a); proto a
 #define RUNTIMESERVICE
 #define RUNTIMEFUNCTION
-
-
-#define RUNTIME_CODE(a)         alloc_text("rtcode", a)
-#define BEGIN_RUNTIME_DATA()    data_seg("rtdata")
-#define END_RUNTIME_DATA()      data_seg("")
-
 #define VOLATILE    volatile
-
-#define MEMORY_FENCE()    
+#define MEMORY_FENCE()
 
 #ifdef EFI_NT_EMULATOR
 

--- a/lib/ia32/math.c
+++ b/lib/ia32/math.c
@@ -18,23 +18,6 @@ Revision History
 #include "lib.h"
 
 
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(LShiftU64)
-#pragma RUNTIME_CODE(RShiftU64)
-#pragma RUNTIME_CODE(MultU64x32)
-#pragma RUNTIME_CODE(DivU64x32)
-#endif
-#endif
-
-//
-//
-//
-
 UINT64
 LShiftU64 (
     IN UINT64   Operand,

--- a/lib/ia64/math.c
+++ b/lib/ia64/math.c
@@ -18,26 +18,6 @@ Revision History
 #include "lib.h"
 
 
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(LShiftU64)
-#pragma RUNTIME_CODE(RShiftU64)
-#pragma RUNTIME_CODE(MultU64x32)
-#pragma RUNTIME_CODE(DivU64x32)
-#endif
-#endif
-
-//
-//
-//
-
-
-
-
 UINT64
 LShiftU64 (
     IN UINT64   Operand,

--- a/lib/print.c
+++ b/lib/print.c
@@ -22,30 +22,6 @@ Revision History
 
 /* VA types/functions can be used if used internally so we can use default va_list always here */
 
-
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(DbgPrint)
-
-// For debugging..
-
-/*
-#pragma RUNTIME_CODE(ValueToHex)
-#pragma RUNTIME_CODE(ValueToString)
-#pragma RUNTIME_CODE(TimeToString)
-*/
-
-#endif /* !defined(__GNUC__) */
-#endif
-
-//
-//
-//
-
 INTN
 DbgPrint (
     IN INTN         mask,

--- a/lib/runtime/efirtlib.c
+++ b/lib/runtime/efirtlib.c
@@ -20,9 +20,6 @@ Revision History
 #include "efilib.h"
 #include "efirtlib.h"
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtZeroMem)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtZeroMem (
@@ -38,9 +35,6 @@ RtZeroMem (
     }
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtSetMem)
-#endif
 VOID
 EFIAPI
 RUNTIMEFUNCTION
@@ -58,9 +52,6 @@ RtSetMem (
     }
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtCopyMem)
-#endif
 VOID
 EFIAPI
 RUNTIMEFUNCTION
@@ -90,9 +81,6 @@ RtCopyMem (
     }
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtCopyMemC)
-#endif
 VOID
 EFIAPI
 RUNTIMEFUNCTION
@@ -109,9 +97,6 @@ RtCopyMemC (
     RtCopyMem(Dest, (VOID*)Src, len);
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtCompareMem)
-#endif
 INTN
 RUNTIMEFUNCTION
 RtCompareMem (
@@ -140,9 +125,6 @@ RtCompareMem (
 
 typedef UINT32 QUAD_UINT32[4]; /* EFI_GUID is 128 bits so 32 x 4 */
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtCompareGuid)
-#endif
 BOOLEAN
 EFIAPI
 RUNTIMEFUNCTION
@@ -188,9 +170,6 @@ Returns:
     }
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtIsZeroGuid)
-#endif
 BOOLEAN
 EFIAPI
 RUNTIMEFUNCTION
@@ -199,5 +178,4 @@ IN CONST EFI_GUID     *Guid1
 )
 {
 	return RtCompareGuid(Guid1, &gZeroGuid);
-
 }

--- a/lib/runtime/rtdata.c
+++ b/lib/runtime/rtdata.c
@@ -20,17 +20,6 @@ Revision History
 
 
 //
-// These globals are runtime globals
-//
-// N.B. The Microsoft C compiler will only put the data in the
-// right data section if it is explicitly initialized..
-//
-
-#ifndef __GNUC__
-#pragma BEGIN_RUNTIME_DATA()
-#endif
-
-//
 // RT - pointer to the runtime table
 //
 

--- a/lib/runtime/rtlock.c
+++ b/lib/runtime/rtlock.c
@@ -20,10 +20,6 @@ Revision History
 #include "lib.h"
 
 
-
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtAcquireLock)
-#endif
 VOID
 RtAcquireLock (
     IN FLOCK    *Lock
@@ -60,9 +56,6 @@ Returns:
 }
 
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtAcquireLock)
-#endif
 VOID
 RtReleaseLock (
     IN FLOCK    *Lock

--- a/lib/runtime/rtstr.c
+++ b/lib/runtime/rtstr.c
@@ -17,9 +17,6 @@ Revision History
 
 #include "lib.h"
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrCmp)
-#endif
 INTN
 RUNTIMEFUNCTION
 RtStrCmp (
@@ -40,9 +37,6 @@ RtStrCmp (
     return *s1 - *s2;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrCpy)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtStrCpy (
@@ -57,9 +51,6 @@ RtStrCpy (
     *Dest = 0;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrnCpy)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtStrnCpy (
@@ -76,9 +67,6 @@ RtStrnCpy (
     RtCopyMemC(Dest, Src, Size * sizeof(CHAR16));
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStpCpy)
-#endif
 CHAR16 *
 RUNTIMEFUNCTION
 RtStpCpy (
@@ -94,9 +82,6 @@ RtStpCpy (
     return Dest;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStpnCpy)
-#endif
 CHAR16 *
 RUNTIMEFUNCTION
 RtStpnCpy (
@@ -114,9 +99,6 @@ RtStpnCpy (
     return Dest + Size;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrCat)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtStrCat (
@@ -127,9 +109,6 @@ RtStrCat (
     RtStrCpy(Dest+RtStrLen(Dest), Src);
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrnCat)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtStrnCat (
@@ -146,9 +125,6 @@ RtStrnCat (
     Dest[DestSize + Size] = '\0';
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrLen)
-#endif
 UINTN
 RUNTIMEFUNCTION
 RtStrLen (
@@ -162,9 +138,6 @@ RtStrLen (
     return len;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrnLen)
-#endif
 UINTN
 RUNTIMEFUNCTION
 RtStrnLen (
@@ -179,9 +152,6 @@ RtStrnLen (
     return i;
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtStrSize)
-#endif
 UINTN
 RUNTIMEFUNCTION
 RtStrSize (
@@ -195,9 +165,6 @@ RtStrSize (
     return (len + 1) * sizeof(CHAR16);
 }
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtBCDtoDecimal)
-#endif
 UINT8
 RUNTIMEFUNCTION
 RtBCDtoDecimal(
@@ -212,10 +179,6 @@ RtBCDtoDecimal(
     return ((UINT8)(Low + (High * 10)));
 }
 
-
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtDecimaltoBCD)
-#endif
 UINT8
 RUNTIMEFUNCTION
 RtDecimaltoBCD (
@@ -229,5 +192,3 @@ RtDecimaltoBCD (
 
     return ((UINT8)(Low + (High << 4)));
 }
-
-

--- a/lib/runtime/vm.c
+++ b/lib/runtime/vm.c
@@ -24,9 +24,6 @@ Revision History
 
 #include "lib.h"
 
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtLibEnableVirtualMappings)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtLibEnableVirtualMappings (
@@ -65,10 +62,6 @@ RtLibEnableVirtualMappings (
     }
 }
 
-
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(RtConvertList)
-#endif
 VOID
 RUNTIMEFUNCTION
 RtConvertList (

--- a/lib/x86_64/math.c
+++ b/lib/x86_64/math.c
@@ -18,23 +18,6 @@ Revision History
 #include "lib.h"
 
 
-//
-// Declare runtime functions
-//
-
-#ifdef RUNTIME_CODE
-#ifndef __GNUC__
-#pragma RUNTIME_CODE(LShiftU64)
-#pragma RUNTIME_CODE(RShiftU64)
-#pragma RUNTIME_CODE(MultU64x32)
-#pragma RUNTIME_CODE(DivU64x32)
-#endif
-#endif
-
-//
-//
-//
-
 UINT64
 LShiftU64 (
     IN UINT64   Operand,


### PR DESCRIPTION
* These macros, that apply exclusively to MSVC, were used to create nonstandard PE segments for RunTime code and RunTime data (that were potentially used at one time to facilitate debugging).
* However, on modern ARM64 platforms, such as Snapdragon X based ones, they appear to trigger an ASSERT, which makes the system reset, which is most likely due to some hardening of the UEFI executable stack, either through leveraging of PAC or, possibly, through applying NX to PE sections that are not conventionally known as code sections.
* At any rate, since these generated rtcode/rtdata sections are specific to gnu-efi and not generated for GCC builds, and considering that the MSVC compiler has native capability for producing EFI PE binaries, this patch updates the library to remove the custom section generation (along with the associated macros) as we don't see any current need for them.