### PR TITLE
x86-64: support building with -mabi=ms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.sw?
+*~
 *.efi
 *.efi.debug
 *.o
@@ -5,3 +7,9 @@
 *.so
 *.tar.*
 *.tar
+/aarch64/
+/arm/
+/ia32/
+/ia64/
+/mips64el/
+/x86_64/

--- a/Make.defaults
+++ b/Make.defaults
@@ -180,6 +180,9 @@ EFI_CFLAGS += -std=c11
 ifeq ($(ARCH),x86_64)
   ifeq ($(GCCNEWENOUGH),1)
     EFI_CFLAGS += -DGNU_EFI_USE_MS_ABI
+    ifeq ($(GNU_EFI_EXPORT_MS_ABI),1)
+      EFI_CFLAGS += -mabi=ms -DGNU_EFI_EXPORT_MS_ABI
+    endif
     ifneq ($(USING_CLANG),clang)
       EFI_CFLAGS +=  -maccumulate-outgoing-args
     endif

--- a/Make.defaults
+++ b/Make.defaults
@@ -270,12 +270,17 @@ ifeq ($(IS_MINGW32),)
   EFI_CFLAGS += -fPIC
 endif
 
+OPTIMIZATION_CFLAGS ?= -O2
+DEBUG_CFLAGS ?= -g
+
 ifeq ($(USING_FREEBSD),1)
-EFI_CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wstrict-prototypes -Werror \
+EFI_CFLAGS  += $(ARCH3264) $(OPTIMIZATION_CFLAGS) $(DEBUG_CFLAGS) \
+           -Wall -Wextra -Wstrict-prototypes -Werror \
            -fno-strict-aliasing \
            -ffreestanding -fno-stack-protector
 else
-EFI_CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wstrict-prototypes -Werror \
+EFI_CFLAGS  += $(ARCH3264) $(OPTIMIZATION_CFLAGS) $(DEBUG_CFLAGS) \
+           -Wall -Wextra -Wstrict-prototypes -Werror \
            -fno-strict-aliasing \
            -ffreestanding -fno-stack-protector \
            $(if $(findstring 0,$(USING_CLANG)),-fno-merge-all-constants,)

--- a/gnuefi/crt0-efi-x86_64.S
+++ b/gnuefi/crt0-efi-x86_64.S
@@ -40,6 +40,28 @@
 	.globl _start
 	.type _start,%function
 _start:
+
+#if defined(GNU_EFI_EXPORT_MS_ABI)
+	pushq %rsi
+	movq %rdx, %rsi
+	pushq %rbx
+	movq %rcx, %rbx
+	movq %rdx, %r9
+	movq %rcx, %r8
+	subq $40, %rsp
+
+	lea _DYNAMIC(%rip), %rdx
+	lea ImageBase(%rip), %rcx
+	call _relocate
+
+	addq $40, %rsp
+	movq %rsi, %rdx
+	movq %rbx, %rcx
+	popq %rbx
+	popq %rsi
+	jmp _entry
+	nop
+#else
 	subq $8, %rsp
 	pushq %rcx
 	pushq %rdx
@@ -59,6 +81,7 @@ _start:
 
 	call _entry
 	addq $8, %rsp
+#endif
 
 .L_exit:	
   	ret

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+ms_va_print.c


### PR DESCRIPTION
This patch series adds support for building on x86_64 with -mabi=ms, thus effectively building the entire library as EFIAPI.

This adds a build variable, GNU_EFI_EXPORT_MS_ABI, that allows an application consuming gnu-efi to build the entire tree with -mabi=ms.  This has numerous advantages, not least traceback handlers that expect that ABI will seamlessly walk the call stack from a faulting function all the way up into the firmware correctly.

This PR also has two minor housekeeping patches - one to add all the build artifacts and other such stuff to .gitignore, and one to make changing compiler options when embedding this library easier.

I have not added CI here, as the easiest way to do it requires what may be a moderately controversial change, so I've bundled them together in a different PR ( https://github.com/ncroxon/gnu-efi/pull/105 )