### PR TITLE
Fix parsing of objcopy version number

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -142,7 +142,7 @@ GCCNEWENOUGH := $(shell ( [ $(GCCVERSION) -gt "4" ]           \
                           && echo 1)
 
 PART_ONE = $(shell echo "$(1)" | cut -f1 -d.)
-PART_TWO = $(shell echo "$(1)" | cut -f2 -d.)
+PART_TWO = $(shell echo "$(1)" | cut -f2 -d. | cut -f1 -d-)
 
 IS_NEW_ENOUGH = $(shell ( [ $(call PART_ONE,$(1)) -gt "$(2)" ] \
                           || ( [ $(call PART_ONE,$(1)) -eq "$(2)" ] \


### PR DESCRIPTION
Currently we just grab either the first or second dot-separated component, which will work fine when building from source or when using Ubuntu; however Fedora includes distro-specific information too, so the version number ends up looking like

```
2.46-3.fc44
```

and that confuses the parsing routines. As a consequence, a bunch of messages like

```
/bin/sh: line 1: [: 46-3: integer expected
```

will get produced and detection will not work correctly.

Make things work as expected in all cases.