### PR TITLE
Revert double x86_64 builds

### DIFF
--- a/.github/workflows/linux-gcc-musl.yml
+++ b/.github/workflows/linux-gcc-musl.yml
@@ -11,12 +11,6 @@ jobs:
         arch: [x64]
         include:
           - arch: x64
-            dir: x64
-            musl: musl-dev
-            cross_compile: x86_64-linux-musl-
-        arch: [x86_64]
-        include:
-          - arch: x86_64
             dir: x86_64
             musl: musl-dev
             cross_compile: x86_64-linux-musl-
@@ -62,15 +56,6 @@ jobs:
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
-          fw_base: OVMF
-        arch: [x86_64]
-        include:
-        - arch: x86_64
-          pkg: qemu-system-x86
-          qemu_arch: x86_64
-          qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
 
     steps:
@@ -91,7 +76,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -100,11 +85,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-        export UEFI_ARCH=${{ matrix.fw_arch }}
+        export UEFI_ARCH=${{ matrix.arch }}
         export UEFI_DIR=./image
         export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image"
         ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.github/workflows/linux-gcc.yml
+++ b/.github/workflows/linux-gcc.yml
@@ -8,18 +8,14 @@ jobs:
 
     strategy:
       matrix:
-        arch: [ia32, x86_64, x64, aa64, arm, riscv64, loongarch64]
+        arch: [ia32, x64, aa64, arm, riscv64, loongarch64]
         include:
           - arch: ia32
             dir: ia32
             gcc: multilib
             cross_compile:
-          - arch: x86_64
-            dir: x86_64
-            gcc: multilib
-            cross_compile:
           - arch: x64
-            dir: x64
+            dir: x86_64
             gcc: multilib
             cross_compile:
           - arch: aa64
@@ -79,49 +75,37 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86_64, x64, ia32, aa64, arm, riscv64, loongarch64]
+        arch: [x64, ia32, aa64, arm, riscv64, loongarch64]
         include:
         - arch: x64
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
-          fw_base: OVMF
-        - arch: x86_64
-          pkg: qemu-system-x86
-          qemu_arch: x86_64
-          qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
         - arch: ia32
           pkg: qemu-system-x86
           qemu_arch: i386
           qemu_opts: -M pc
-          fw_arch: ia32
           fw_base: OVMF
         - arch: aa64
           pkg: qemu-system-arm
           qemu_arch: aarch64
           qemu_opts: -M virt -cpu cortex-a57
-          fw_arch: aa64
           fw_base: AAVMF
         - arch: arm
           pkg: qemu-system-arm
           qemu_arch: arm
           qemu_opts: -M virt -cpu cortex-a15
-          fw_arch: arm
           fw_base: AAVMF
         - arch: riscv64
           pkg: qemu-system-riscv64
           qemu_arch: riscv64
           qemu_opts: -M virt,pflash0=pflash0
-          fw_arch: riscv64
           fw_base: QEMU_EFI
         - arch: loongarch64
           pkg: qemu-system-loongarch64
           qemu_arch: loongarch64
           qemu_opts: -M virt -cpu la464
-          fw_arch: loongarch64
           fw_base: QEMU_EFI
 
     steps:
@@ -142,7 +126,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -151,11 +135,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-        export UEFI_ARCH=${{ matrix.fw_arch }}
+        export UEFI_ARCH=${{ matrix.arch }}
         export UEFI_DIR=./image
         if [ "$UEFI_ARCH" = "riscv64" ]; then
           export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -L . -blockdev node-name=pflash0,driver=file,read-only=on,filename=${{ matrix.fw_base }}.fd -drive format=raw,file=fat:rw:image,id=drv1 -device virtio-blk-device,drive=drv1"

--- a/.github/workflows/linux-llvm.yml
+++ b/.github/workflows/linux-llvm.yml
@@ -11,12 +11,6 @@ jobs:
         arch: [x64]
         include:
           - arch: x64
-            dir: x64
-            gcc: multilib
-            cross_compile:
-        arch: [x86_64]
-        include:
-          - arch: x86_64
             dir: x86_64
             gcc: multilib
             cross_compile:
@@ -56,15 +50,6 @@ jobs:
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
-          fw_base: OVMF
-        arch: [x86_64]
-        include:
-        - arch: x86_64
-          pkg: qemu-system-x86
-          qemu_arch: x86_64
-          qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
 
     steps:
@@ -85,7 +70,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -94,11 +79,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-        export UEFI_ARCH=${{ matrix.fw_arch }}
+        export UEFI_ARCH=${{ matrix.arch }}
         export UEFI_DIR=./image
         export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image"
         ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.github/workflows/linux-mingw.yml
+++ b/.github/workflows/linux-mingw.yml
@@ -8,9 +8,9 @@ jobs:
     
     strategy:
       matrix:
-        arch: [x86_64, ia32]
+        arch: [x64, ia32]
         include:
-        - arch: x86_64
+        - arch: x64
           dir: x86_64
           pkg: gcc-mingw-w64-x86-64
           tuple: x86_64-w64-mingw32-
@@ -43,19 +43,17 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86_64, ia32]
+        arch: [x64, ia32]
         include:
-        - arch: x86_64
+        - arch: x64
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
         - arch: ia32
           pkg: qemu-system-x86
           qemu_arch: i386
           qemu_opts: -M pc
-          fw_arch: ia32
           fw_base: OVMF
 
     steps:
@@ -76,7 +74,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -85,11 +83,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-         export UEFI_ARCH=${{ matrix.fw_arch }}
+         export UEFI_ARCH=${{ matrix.arch }}
          export UEFI_DIR=./image
          export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image -nodefaults -nographic -serial stdio -net none"
          ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -8,17 +8,13 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x64, ia32, x86_64, aa64, arm]
+        arch: [ia32, x64, aa64, arm]
         include:
           - arch: ia32
             dir: ia32
             cross_compile: i686-elf-
             toolchain: i686-elf-gcc
           - arch: x64
-            dir: x64
-            cross_compile: x86_64-elf-
-            toolchain: x86_64-elf-gcc
-          - arch: x86_64
             dir: x86_64
             cross_compile: x86_64-elf-
             toolchain: x86_64-elf-gcc
@@ -62,37 +58,27 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x64, ia32, x86_64, aa64, arm]
+        arch: [ia32, x64, aa64, arm]
         include:
         - arch: x64
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
-          fw_base: OVMF
-        - arch: x86_64
-          pkg: qemu-system-x86
-          qemu_arch: x86_64
-          qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
         - arch: ia32
           pkg: qemu-system-x86
           qemu_arch: i386
           qemu_opts: -M pc
-          fw_arch: ia32
           fw_base: OVMF
         - arch: aa64
           pkg: qemu-system-arm
           qemu_arch: aarch64
           qemu_opts: -M virt -cpu cortex-a57
-          fw_arch: aa64
           fw_base: AAVMF
         - arch: arm
           pkg: qemu-system-arm
           qemu_arch: arm
           qemu_opts: -M virt -cpu cortex-a15
-          fw_arch: arm
           fw_base: AAVMF
 
     steps:
@@ -113,7 +99,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -122,11 +108,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-        export UEFI_ARCH=${{ matrix.fw_arch }}
+        export UEFI_ARCH=${{ matrix.arch }}
         export UEFI_DIR=./image
         export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -nodefaults -nographic -serial stdio -net none -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image"
         ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -8,13 +8,9 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x64, x86_64, ia32]
+        arch: [x64, ia32]
         include:
           - arch: x64
-            dir: x64 
-            sys: mingw64
-            env: x86_64
-          - arch: x86_64
             dir: x86_64 
             sys: mingw64
             env: x86_64
@@ -44,7 +40,7 @@ jobs:
         fetch-depth: 0
 
     - name: Build
-      run: make ARCH=${{ matrix.arch }}
+      run: make
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
@@ -58,25 +54,17 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x64, x86_64, ia32]
+        arch: [x64, ia32]
         include:
         - arch: x64
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
-          fw_base: OVMF
-        - arch: x86_64
-          pkg: qemu-system-x86
-          qemu_arch: x86_64
-          qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
         - arch: ia32
           pkg: qemu-system-x86
           qemu_arch: i386
           qemu_opts: -M pc
-          fw_arch: ia32
           fw_base: OVMF
 
     steps:
@@ -97,7 +85,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -106,11 +94,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-         export UEFI_ARCH=${{ matrix.fw_arch }}
+         export UEFI_ARCH=${{ matrix.arch }}
          export UEFI_DIR=./image
          export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image -nodefaults -nographic -serial stdio -net none"
          ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.github/workflows/windows-vs2026.yml
+++ b/.github/workflows/windows-vs2026.yml
@@ -45,19 +45,16 @@ jobs:
           pkg: qemu-system-x86
           qemu_arch: x86_64
           qemu_opts: -M q35
-          fw_arch: x64
           fw_base: OVMF
         - arch: ia32
           pkg: qemu-system-x86
           qemu_arch: i386
           qemu_opts: -M pc
-          fw_arch: ia32
           fw_base: OVMF
         - arch: aa64
           pkg: qemu-system-arm
           qemu_arch: aarch64
           qemu_opts: -M virt -cpu cortex-a57
-          fw_arch: aa64
           fw_base: AAVMF
 
     steps:
@@ -78,7 +75,7 @@ jobs:
 
     - name: Download UEFI firmware
       run: |
-        fw_arch=$(echo ${{ matrix.fw_arch }} | tr a-z A-Z)
+        fw_arch=$(echo ${{ matrix.arch }} | tr a-z A-Z)
         fw_zip=${{ matrix.fw_base }}-${fw_arch}.zip
         curl -O https://efi.akeo.ie/${{ matrix.fw_base }}/${fw_zip}
         7z x ${fw_zip}
@@ -87,11 +84,11 @@ jobs:
     - name: Download UEFI Shell
       run: |
         mkdir -p ./image/efi/boot
-        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.fw_arch }}.efi -o ./image/efi/boot/boot${{ matrix.fw_arch }}.efi
+        curl -L https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shell${{ matrix.arch }}.efi -o ./image/efi/boot/boot${{ matrix.arch }}.efi
 
     - name: Run tests
       run: |
-         export UEFI_ARCH=${{ matrix.fw_arch }}
+         export UEFI_ARCH=${{ matrix.arch }}
          export UEFI_DIR=./image
          export QEMU_CMD="qemu-system-${{ matrix.qemu_arch }} ${{ matrix.qemu_opts }} -L . -drive if=pflash,format=raw,unit=0,file=${{ matrix.fw_base }}.fd,readonly=on -drive format=raw,file=fat:rw:image -nodefaults -nographic -serial stdio -net none"
          ./tests/gen_tests.sh ./tests/test_list.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 /ia64/
 /mips64el/
 /x86_64/
-/x64/
+/lib/ms_va_print.c

--- a/Make.defaults
+++ b/Make.defaults
@@ -113,6 +113,9 @@ ifeq ($(ARCH),amd64)
 endif
 
 # Allow UEFI shorthands to be specified for the arch
+ifeq ($(ARCH),x64)
+  override ARCH := x86_64
+endif
 ifeq ($(ARCH),mips64)
   override ARCH := mips64el
 endif
@@ -138,17 +141,6 @@ GCCNEWENOUGH := $(shell ( [ $(GCCVERSION) -gt "4" ]           \
                           && [ $(GCCMINOR) -ge "7" ] ) ) \
                           && echo 1)
 
-#
-# if we don't supprt -mabi=ms, the user definitely wants the old UEFI shorthand
-# name behavior for ARCH=x64
-#
-ifeq ($(GCCNEWENOUGH),0)
-  ifeq ($(ARCH),x64)
-    override ARCH := x86_64
-  endif
-endif
-SRC_ARCH=$(ARCH)
-
 PART_ONE = $(shell echo "$(1)" | cut -f1 -d.)
 PART_TWO = $(shell echo "$(1)" | cut -f2 -d. | cut -f1 -d-)
 
@@ -167,7 +159,7 @@ OBJDIR       := $(TOPDIR)/$(ARCH)
 #
 
 # Arch-specific compilation flags
-EFI_CFLAGS += -DCONFIG_$(SRC_ARCH)
+EFI_CFLAGS += -DCONFIG_$(ARCH)
 
 EFI_CFLAGS += -Wno-error=pragmas
 
@@ -201,23 +193,8 @@ ifeq ($(ARCH),x86_64)
     ARCH3264 = -m64
   endif
 endif
-ifeq ($(ARCH),x64)
-  ifeq ($(GCCNEWENOUGH),0)
-    $(error this needs newer gcc)
-  endif
-  EFI_CFLAGS += -DGNU_EFI_USE_MS_ABI -mabi=ms -DGNU_EFI_EXPORT_MS_ABI
-  ifneq ($(USING_CLANG),clang)
-    EFI_CFLAGS +=  -maccumulate-outgoing-args
-  endif
 
-  EFI_CFLAGS += -mno-red-zone
-  ifeq ($(HOSTARCH),ia32)
-    ARCH3264 = -m64
-  endif
-  SRC_ARCH=x86_64
-endif
-
-ifneq (,$(filter $(ARCH),ia32 x86_64 x64))
+ifneq (,$(filter $(ARCH),ia32 x86_64))
   # Disable AVX, if the compiler supports that.
   CC_CAN_DISABLE_AVX=$(shell $(CC) -Werror -c -o /dev/null -xc -mno-avx - </dev/null >/dev/null 2>&1 && echo 1)
   ifeq ($(CC_CAN_DISABLE_AVX), 1)

--- a/Make.rules
+++ b/Make.rules
@@ -70,10 +70,6 @@ endif
 	@$(ECHO) "  CC       $(notdir $@)"
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -c $< -o $@
 
-$(ARCH)/%.o: $(SRC_ARCH)/%.c
-	@$(ECHO) "  CC       $(notdir $@)"
-	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -c $< -o $@
-
 %.s: %.c
 	@$(ECHO) "  CC       $(notdir $@)"
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -S $< -o $@
@@ -83,10 +79,6 @@ $(ARCH)/%.o: $(SRC_ARCH)/%.c
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -E $< -o $@
 
 %.o: %.S
-	@$(ECHO) "  AS       $(notdir $@)"
-	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -c $< -o $@
-
-$(ARCH)/%.o: $(SRC_ARCH)/%.S
 	@$(ECHO) "  AS       $(notdir $@)"
 	$(HIDE)$(CC) $(INCDIR) $(CFLAGS) -c $< -o $@
 

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -57,9 +57,9 @@ CRT0_LIBS	= -lgnuefi
 endif
 
 ifneq ($(CRT0_LIBS),)
-CRTOBJS		= $(TOPDIR)/$(ARCH)/gnuefi/crt0-efi-$(SRC_ARCH)$(CRT0_LOCAL).o
+CRTOBJS		= $(TOPDIR)/$(ARCH)/gnuefi/crt0-efi-$(ARCH)$(CRT0_LOCAL).o
 
-LDSCRIPT	= $(TOPDIR)/gnuefi/elf_$(SRC_ARCH)_efi$(LDS_LOCAL).lds
+LDSCRIPT	= $(TOPDIR)/gnuefi/elf_$(ARCH)_efi$(LDS_LOCAL).lds
 ifeq ($(USING_FREEBSD),1)
 LDSCRIPT	= $(TOPDIR)/gnuefi/elf_$(ARCH)_fbsd_efi.lds
 endif
@@ -99,9 +99,9 @@ $(TARGET_RTDRIVERS): SUBSYSTEM = 0xc
 
 ifeq ($(SYSTEM_HAS_EFI_OBJCOPY),1)
 
-FORMAT		:= -O efi-app-$(SRC_ARCH)
-$(TARGET_BSDRIVERS): FORMAT=-O efi-bsdrv-$(SRC_ARCH)
-$(TARGET_RTDRIVERS): FORMAT=-O efi-rtdrv-$(SRC_ARCH)
+FORMAT		:= -O efi-app-$(ARCH)
+$(TARGET_BSDRIVERS): FORMAT=-O efi-bsdrv-$(ARCH)
+$(TARGET_RTDRIVERS): FORMAT=-O efi-rtdrv-$(ARCH)
 
 ifneq ($(IS_MINGW32),)
 EFI_LDFLAGS += -s -Wl,-dll

--- a/gnuefi/Makefile
+++ b/gnuefi/Makefile
@@ -40,7 +40,7 @@ SRCDIR = $(VPATH)
 include $(SRCDIR)/../Make.defaults
 
 PKGCONFIGDIR ?= $(LIBDIR)/pkgconfig
-FILES	= reloc_$(SRC_ARCH)
+FILES	= reloc_$(ARCH)  
 
 OBJS	= $(FILES:%=%.o)
 
@@ -50,9 +50,6 @@ else
   gnu_efi_default_is_objcopy=false
 endif
 # https://uefi.org/specs/UEFI/2.10/03_Boot_Manager.html#uefi-image-types
-ifeq ($(ARCH),x64)
-  efi_machine_type_name=x64
-endif
 ifeq ($(ARCH),x86_64)
   efi_machine_type_name=x64
 endif
@@ -82,7 +79,7 @@ ifneq (,$(filter $(ARCH),aarch64 riscv64 ia32))
 CRT0_LOCAL_TARGET = crt0-efi-$(ARCH)-local.o
 endif
 
-LIBS = crt0-efi-$(SRC_ARCH).o libgnuefi.a $(CRT0_LOCAL_TARGET)
+LIBS = crt0-efi-$(ARCH).o libgnuefi.a $(CRT0_LOCAL_TARGET)
 TARGETS	= $(LIBS) gnu-efi.pc
 
 all:	$(TARGETS)
@@ -115,12 +112,12 @@ install:
 	mkdir -p $(INSTALLROOT)$(LIBDIR)
 	$(INSTALL) -m 644 $(LIBS) $(INSTALLROOT)$(LIBDIR)
 ifneq (,$(filter $(ARCH),x86_64 ia32))
-	$(INSTALL) -m 644 $(SRCDIR)/elf_$(SRC_ARCH)_fbsd_efi.lds $(INSTALLROOT)$(LIBDIR)
+	$(INSTALL) -m 644 $(SRCDIR)/elf_$(ARCH)_fbsd_efi.lds $(INSTALLROOT)$(LIBDIR)
 endif
 ifneq (,$(filter $(ARCH),aarch64 riscv64 ia32))
-	$(INSTALL) -m 644 $(SRCDIR)/elf_$(SRC_ARCH)_efi_local.lds $(INSTALLROOT)$(LIBDIR)
+	$(INSTALL) -m 644 $(SRCDIR)/elf_$(ARCH)_efi_local.lds $(INSTALLROOT)$(LIBDIR)
 endif
-	$(INSTALL) -m 644 $(SRCDIR)/elf_$(SRC_ARCH)_efi.lds $(INSTALLROOT)$(LIBDIR)
+	$(INSTALL) -m 644 $(SRCDIR)/elf_$(ARCH)_efi.lds $(INSTALLROOT)$(LIBDIR)
 	$(INSTALL) -d $(INSTALLROOT)$(PKGCONFIGDIR)
 	$(INSTALL) -m 644 gnu-efi.pc $(INSTALLROOT)$(PKGCONFIGDIR)
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,0 @@
-ms_va_print.c

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -44,15 +44,15 @@ FILES = boxdraw smbios console crc data debug dpath \
         entry error event exit guid hand hw init lock \
         misc pause sread str cmdline runtime/rtlock \
         runtime/efirtlib runtime/rtstr runtime/vm runtime/rtdata \
-        $(SRC_ARCH)/initplat $(SRC_ARCH)/math $(SRC_ARCH)/setjmp \
+        $(ARCH)/initplat $(ARCH)/math $(ARCH)/setjmp \
         ctors print ms_va_print va_print
 
 ifeq ($(ARCH),ia64)
 FILES += $(ARCH)/salpal $(ARCH)/palproc
 endif
 
-ifneq (,$(filter $(ARCH),x64 x86_64))
-FILES += $(SRC_ARCH)/callwrap $(SRC_ARCH)/efi_stub
+ifeq ($(ARCH),x86_64)
+FILES += $(ARCH)/callwrap $(ARCH)/efi_stub
 endif
 
 ifeq ($(ARCH),arm)
@@ -60,9 +60,9 @@ FILES += $(ARCH)/uldiv $(ARCH)/ldivmod $(ARCH)/div $(ARCH)/llsl $(ARCH)/llsr \
 	 $(ARCH)/mullu
 endif
 
-OBJS = $(subst $(SRC_ARCH)/,$(ARCH)/,$(FILES:%=%.o))
+OBJS  = $(FILES:%=%.o)
 
-SUBDIRS = x64 ia32 x86_64 ia64 aarch64 arm mips64el riscv64 loongarch64 runtime
+SUBDIRS = ia32 x86_64 ia64 aarch64 arm mips64el riscv64 loongarch64 runtime
 
 all:	libefi.a
 


### PR DESCRIPTION
As explained in #105, we don't really want to have to carry two versions of the x86_64 arch depending on whether a flag is being used or not. Instead we want to have a main x86_64 build that uses the default flags, with these defaults evolving, as needed, through major and minor version bumps.

Therefore, this patch reverts the following commits:
- ed3ffa376bbdafa71b75370e6ebedcf6755225e7
- 9bb1ba08644c296409360f92cf71cd3271315675
- 111182537f9083b6e65f47b14cbd1840ca354b54
- e5810c26fa2dc92c0cb578a5a7cf063c9bb78c99

We also remove the separate lib/.gitignore as the main .gitignore is more than enough to filter any content we want to filter out and it makes it much easier to both let users of gnu-efi what is actually being filtered, as well as maintain ignored files.