### PR TITLE
loongarch64: Remove unnecessary handling of DT_PLTGOT

### DIFF
--- a/gnuefi/reloc_loongarch64.c
+++ b/gnuefi/reloc_loongarch64.c
@@ -65,12 +65,6 @@ EFI_STATUS _relocate (long ldbase, Elf64_Dyn *dyn,
 				relent = dyn[i].d_un.d_val;
 				break;
 
-			case DT_PLTGOT:
-				addr = (unsigned long *)
-					((unsigned long)dyn[i].d_un.d_ptr
-					 + ldbase);
-				break;
-
 			default:
 				break;
 		}


### PR DESCRIPTION
The loongarch64 relocator looks for DT_PLTGOT tag and records its value, but never makes use of it, which seems some left-over when converting from the mips64el port. Remove it.